### PR TITLE
Add simplify expression

### DIFF
--- a/funcdle.js
+++ b/funcdle.js
@@ -143,7 +143,7 @@ function guessGraph(f, guess, gid) {
     const _y = evaluate(f, x);
     const y = evaluate(guess, x);
 
-    if (isNaN(y)) {
+    if (isNaN(y) || !isFinite(y)) {
       x += dx;
     } else {
       const d = _y - y;

--- a/funcdle.js
+++ b/funcdle.js
@@ -138,6 +138,7 @@ function draw(x, y, color, highlightColor, gid) {
 
 function guessGraph(f, guess, gid) {
   let x = -size + 0.01;
+  const dguess = simplify(derivative(simplify(guess)));
   while (x <= size) {
     const _y = evaluate(f, x);
     const y = evaluate(guess, x);
@@ -151,7 +152,7 @@ function guessGraph(f, guess, gid) {
       const highlightColor = isNear ? nearHighlight : farHighlight;
       draw(x, y, color, highlightColor, gid);
 
-      const gpx = evaluate(derivative(guess), x);
+      const gpx = evaluate(dguess, x);
       const inc = dx / Math.sqrt(gpx * gpx + 1);
       if (isNaN(inc) || inc < mdx)
         x += mdx;

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -100,16 +100,16 @@ object Main {
       case Add(l, r) => Add(normalize(l), normalize(r))
       case Sub(l, r) => Sub(normalize(l), normalize(r))
       case Mul(l, r) => Mul(normalize(l), normalize(r))
-      case Div(l, r) => Div(normalize(l), normalize(r))
+      case Div(n, d) => Div(normalize(n), normalize(d))
       case Pow(l, r) => Pow(normalize(l), normalize(r))
     }
     def aux(e: Expr): Expr = ({
       case Mul(e, Num(n)) if !e.isInstanceOf[Num] => Mul(Num(n), e)
-      case Mul(Div(e1, e2), Div(e3, e4)) => Div((Mul(e1, e2)), (Mul(e3, e4)))
-      case Mul(Div(e1, e2), e3)          => Div((Mul(e1, e3)), e2)
-      case Mul(e1, Div(e2, e3))          => Div((Mul(e1, e2)), e3)
-      case Div(e1, Div(e2, e3))          => Div((Mul(e1, e3)), e2)
-      case Div(Div(e1, e2), e3)          => Div(e1, (Mul(e2, e3)))
+      case Mul(Div(n1, d1), Div(n2, d2)) => Div(Mul(n1, n2), Mul(d1, d2))
+      case Mul(Div(n1, d1), e2)          => Div(Mul(n1, e2), d1)
+      case Mul(e1, Div(n2, d2))          => Div(Mul(e1, n2), d2)
+      case Div(e1, Div(n2, d2))          => Div(Mul(e1, d2), n2)
+      case Div(Div(n1, d1), e2)          => Div(n1, Mul(d1, e2))
       case Add(e, Num(n)) if !e.isInstanceOf[Num] => Add(Num(n), e)
     }: PartialFunction[Expr, Expr])
       .andThen(aux _)
@@ -127,7 +127,7 @@ object Main {
       case Add(l, r) => Add(reduce(l), reduce(r))
       case Sub(l, r) => Sub(reduce(l), reduce(r))
       case Mul(l, r) => Mul(reduce(l), reduce(r))
-      case Div(l, r) => Div(reduce(l), reduce(r))
+      case Div(n, d) => Div(reduce(n), reduce(d))
       case Pow(l, r) => Pow(reduce(l), reduce(r))
     }
 

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -86,6 +86,85 @@ object Main {
       )
   }
 
+  @JSExportTopLevel("simplify")
+  def simplify(e: Expr): Expr = reduce(normalize(reduce(normalize(e))))
+
+  // Normalize expression to help reduce
+  def normalize(e: Expr): Expr = {
+    val ne = e match {
+      case X         => X
+      case Num(n)    => Num(n)
+      case Neg(e)    => Neg(normalize(e))
+      case Sqrt(e)   => Sqrt(normalize(e))
+      case Ln(e)     => Ln(normalize(e))
+      case Add(l, r) => Add(normalize(l), normalize(r))
+      case Sub(l, r) => Sub(normalize(l), normalize(r))
+      case Mul(l, r) => Mul(normalize(l), normalize(r))
+      case Div(l, r) => Div(normalize(l), normalize(r))
+      case Pow(l, r) => Pow(normalize(l), normalize(r))
+    }
+    def aux(e: Expr): Expr = ({
+      case Mul(e, Num(n)) if !e.isInstanceOf[Num] => Mul(Num(n), e)
+      case Mul(Div(e1, e2), Div(e3, e4)) => Div((Mul(e1, e2)), (Mul(e3, e4)))
+      case Mul(Div(e1, e2), e3)          => Div((Mul(e1, e3)), e2)
+      case Mul(e1, Div(e2, e3))          => Div((Mul(e1, e2)), e3)
+      case Div(e1, Div(e2, e3))          => Div((Mul(e1, e3)), e2)
+      case Div(Div(e1, e2), e3)          => Div(e1, (Mul(e2, e3)))
+      case Add(e, Num(n)) if !e.isInstanceOf[Num] => Add(Num(n), e)
+    }: PartialFunction[Expr, Expr])
+      .andThen(aux _)
+      .applyOrElse(e, identity[Expr] _)
+    aux(ne)
+  }
+
+  def reduce(e: Expr): Expr = {
+    val ne = e match {
+      case X         => X
+      case Num(n)    => Num(n)
+      case Neg(e)    => Neg(reduce(e))
+      case Sqrt(e)   => Sqrt(reduce(e))
+      case Ln(e)     => Ln(reduce(e))
+      case Add(l, r) => Add(reduce(l), reduce(r))
+      case Sub(l, r) => Sub(reduce(l), reduce(r))
+      case Mul(l, r) => Mul(reduce(l), reduce(r))
+      case Div(l, r) => Div(reduce(l), reduce(r))
+      case Pow(l, r) => Pow(reduce(l), reduce(r))
+    }
+
+    def aux(e: Expr): Expr = ({
+      case Mul(Num(1), e)              => e
+      case Mul(Num(0), e)              => Num(0)
+      case Mul(Num(n), Num(m))         => Num(n * m)
+      case Neg(Neg(e))                 => e
+      case Neg(Num(n))                 => Num(-n)
+      case Mul(Num(n), Mul(Num(m), e)) => (Mul(Num(n * m), e))
+      case Mul(Mul(Num(n), e1), Mul(Num(m), e2)) => (
+        Mul(Mul(Num(n * m), e1), e2)
+      )
+      case Div(e, Num(1))                      => e
+      case Div(Num(0), e)                      => Num(0)
+      case Add(Num(n), Num(m))                 => Num(n + m)
+      case Add(Num(0), e)                      => e
+      case Add(Mul(Num(n), X), Mul(Num(m), X)) => Mul(Num(n + m), X)
+      case Add(Mul(Num(n), X), Neg(X))         => Mul(Num(n - 1), X)
+      case Add(Neg(X), Mul(Num(n), X))         => Mul(Num(n - 1), X)
+      case Add(Num(n), Add(Num(m), e))         => (Add(Num(n + m), e))
+      case Add(Num(n), Sub(Num(m), e))         => (Sub(Num(n - m), e))
+      case Sub(Num(n), Num(m))                 => Num(n - m)
+      case Sub(e, Num(0))                      => e
+      case Pow(e, Num(1))                      => e
+      case Pow(Num(1), e)                      => Num(1)
+      case Pow(Num(n), Num(m))                 => Num(math.pow(n, m).toInt)
+      case Sub(Num(0), e)                      => Neg(e)
+      case Sub(Mul(Num(n), X), Mul(Num(m), X)) => Mul(Num(n - m), X)
+      case Sub(Mul(Num(n), X), Neg(X))         => Mul(Num(n + 1), X)
+      case Sub(Neg(X), Mul(Num(n), X))         => Mul(Num(-1 - n), X)
+    }: PartialFunction[Expr, Expr])
+      .andThen(aux _)
+      .applyOrElse(e, identity[Expr] _)
+    aux(ne)
+  }
+
   val r = new scala.util.Random
 
   @JSExportTopLevel("rand")


### PR DESCRIPTION
This pull request suggests to add simplify method to reduce expression for effective calculation of derivative. I made two changes:
1) change the location of calculating derivative before loop start
2) add simplify method and using it when calculating derivative

To show the effectiveness of this pull request, I measure the execution time of `guessGraph` function for six inputs. 

| Function | Enable 1+2 | Enable 1 | Original |
| ------ | ---------- | -------- | --------- |
| 1+2/x |  140 ms | 168 ms | 205 ms |
| x^㏑√x |  183 ms | 207 ms | 139 ms |
| x^x^x |  1696 ms | 2219 ms | 2822 ms |
| x*x^x |  3553 ms | 4121 ms | 4732 ms |
| x/x^x |  293 ms | 287 ms | 294 ms |
| x/√√x |  47 ms | 33 ms | 38 ms |

Even it has overhead to compute simplify method, it reduces much time for complex function.